### PR TITLE
Fix: Left operand of 'is' is a previously freed instance.

### DIFF
--- a/gui/mtools_edit_mode_selector.gd
+++ b/gui/mtools_edit_mode_selector.gd
@@ -106,17 +106,18 @@ func change_active_object(object):
 		active_object = null
 	exit_edit_mode_button.visible = false
 	edit_selected_button.visible = true
-	if object is MTerrain:
-		active_object = object
-		edit_selected_button.text = "Click to Sculpt " + object.name
-	elif object is MGrass or object is MNavigationRegion3D:
-		active_object = object
-		edit_selected_button.text = "Click to Paint " + object.name			
-	elif object is MPath or object is MCurveMesh:
-		active_object = object
-		edit_selected_button.text = "Click to Edit " + object.name		
-	else:
-		edit_selected_button.visible = false
+	if object:
+		if object is MTerrain:
+			active_object = object
+			edit_selected_button.text = "Click to Sculpt " + object.name
+		elif object is MGrass or object is MNavigationRegion3D:
+			active_object = object
+			edit_selected_button.text = "Click to Paint " + object.name			
+		elif object is MPath or object is MCurveMesh:
+			active_object = object
+			edit_selected_button.text = "Click to Edit " + object.name		
+		else:
+			edit_selected_button.visible = false
 		
 	text = ""
 	theme_type_variation


### PR DESCRIPTION
I got the following error. I fixed it by placing a verification. 

The error:

> 

ERROR: Attempted to find an invalid (previously freed?) object instance into a 'TypedArray.
   at: validate_object (core/variant/container_type_validate.h:116)
ERROR: Condition "!_p->typed.validate(value, "find")" is true. Returning: -1
   at: find (core/variant/array.cpp:354)
SCRIPT ERROR: Left operand of 'is' is a previously freed instance.
          at: change_active_object (res://addons/m_terrain/gui/mtools_edit_mode_selector.gd:109)

![20241020_12h41m42s_grim](https://github.com/user-attachments/assets/240c9f7d-0c79-4233-a487-1fa26ee560c6)


How I fixed:

> 
	if object:

		if object is MTerrain:
			active_object = object
			edit_selected_button.text = "Click to Sculpt " + object.name
		elif object is MGrass or object is MNavigationRegion3D:
			active_object = object
			edit_selected_button.text = "Click to Paint " + object.name			
		elif object is MPath or object is MCurveMesh:
			active_object = object
			edit_selected_button.text = "Click to Edit " + object.name		
		else:
			edit_selected_button.visible = false
		

![20241020_12h50m10s_grim](https://github.com/user-attachments/assets/24fdf993-4f0e-4b71-8f4a-434251216ad0)
