### PR TITLE
fixed subcollection import issues

### DIFF
--- a/asset_manager/asset_io.gd
+++ b/asset_manager/asset_io.gd
@@ -109,8 +109,9 @@ static func generate_asset_data_from_glb(scene:Array,active_collection="__root__
 				asset_data.add_mesh_data(material_sets, mmesh, node)
 				asset_data.update_collection_mesh(mesh_item_name,name_data.lod,mmesh)
 				var collection_name = mesh_item_name if active_collection == "__root__" else active_collection
-				if not active_collection == "__root__":
-					asset_data.add_sub_collection(active_collection,mesh_item_name,node.transform)
+				if not active_collection == "__root__":					
+					if active_collection != mesh_item_name:
+						asset_data.add_sub_collection(active_collection,mesh_item_name,node.transform)
 			#MAKE MATERIAL SET NAMING CONVENTION
 			else: 
 				var mesh_item_name = name_data["name"]
@@ -132,8 +133,9 @@ static func generate_asset_data_from_glb(scene:Array,active_collection="__root__
 				asset_data.add_mesh_data(material_set,mmesh, node)
 				asset_data.update_collection_mesh(mesh_item_name,name_data["lod"],mmesh)
 				# if we are not on root then we add ourself as sub collection to whatever active_collection is
-				if not active_collection == "__root__":
-					asset_data.add_sub_collection(active_collection,mesh_item_name,node.transform)				
+				if not active_collection == "__root__":					
+					if active_collection != mesh_item_name:
+						asset_data.add_sub_collection(active_collection,mesh_item_name,node.transform)				
 			if child_count > 0:
 				push_error(node.name + " can not have children! ignoring its children! this can be due to naming with _lod of that or it is a mesh!")									
 		############################
@@ -322,7 +324,10 @@ static func import_collection(glb_node_name:String,glb_id:int,func_depth:=0):
 			sub_collection_id = asset_data.get_collection_id(sub_collection_name)
 			if not asset_library.has_collection(sub_collection_id):
 				push_error("trying to add subcollection to collection, but sub_collection_id ", sub_collection_id, " does not exist")
-			asset_library.collection_add_sub_collection(collection_id, sub_collection_id,sub_collections[sub_collection_name])
+			for sub_collection_transform in sub_collections[sub_collection_name]:
+				if not asset_library.has_collection(sub_collection_id):
+					push_error("trying to add subcollection to collection, but sub_collection_id ", sub_collection_id, " does not exist")
+				asset_library.collection_add_sub_collection(collection_id, sub_collection_id, sub_collection_transform)									
 	## ADD TAGS
 	if collection_id != -1:		
 		if asset_data.tags.mode == 0:

--- a/asset_manager/asset_io_data.gd
+++ b/asset_manager/asset_io_data.gd
@@ -138,7 +138,9 @@ func add_master_collection(node_name:String,transform:Transform3D):
 func add_sub_collection(node_name:String,sub_collection_node_name:String,sub_collection_transform:Transform3D):
 	if not collections.has(node_name):
 		collections[node_name] = get_empty_collection()
-	collections[node_name]["sub_collections"][sub_collection_node_name] = sub_collection_transform
+	if not collections[node_name]["sub_collections"].has(sub_collection_node_name):
+		collections[node_name]["sub_collections"][sub_collection_node_name] = []
+	collections[node_name]["sub_collections"][sub_collection_node_name].push_back(sub_collection_transform)
 	collections[node_name]["is_master"] = true
 
 	
@@ -420,9 +422,9 @@ func add_glb_import_info(info:Dictionary)->void:
 		if mesh_id!=-1:
 			original_meshes = MAssetTable.mesh_item_meshes_no_replace(mesh_id)
 		var original_sub_collections:Dictionary = info[collection_glb_name]["sub_collections"]		
-		for sub_collection_name in original_sub_collections:
-			var t = asset_library.collection_get_sub_collections_transform(collection_id,original_sub_collections[sub_collection_name])
-			collections[collection_glb_name]["original_sub_collections"][sub_collection_name] = t
+		#for sub_collection_name in original_sub_collections:
+		#	var t = asset_library.collection_get_sub_collections_transform(collection_id,original_sub_collections[sub_collection_name])
+		#	collections[collection_glb_name]["original_sub_collections"][sub_collection_name] = t
 		collections[collection_glb_name]["id"] = collection_id
 		collections[collection_glb_name]["original_meshes"] = original_meshes
 		if collection_id >= 0 and asset_library.has_collection(collection_id):


### PR DESCRIPTION
fixed if a parent empty has the same name as a mesh subcollection, everything breaks
fixed subcollections can now have multiple transforms ( i thought we had already done this, not sure why it didn't exist)

TODO: 
it seems like asset_library.collection_get_sub_collections_transform function is missing! this is necessary for import info. 